### PR TITLE
Coming in with the D

### DIFF
--- a/Data/.gitignore
+++ b/Data/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!OOD_texts.txt

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!OOD_texts.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ tensorboard==2.17.0
 fastapi==0.112.1
 starlette==0.38.2
 
-git+https://github.com/m-bain/whisperx.git@58f00339af7dcc9705ef49d97a1f40764b7cf555
+git+https://github.com/m-bain/whisperx.git@main
 git+https://github.com/resemble-ai/monotonic_align.git@78b985be210a03d08bc3acc01c4df0442105366f


### PR DESCRIPTION
Linux file paths are case sensitive, changed ```data/``` folder to ```Data/```. Shouldn't  matter on windows as its case insensitive. All yaml's are already using the capital "D" too. Whisperx was throwing an http error indicating they moved the URL. So I swapped in a solution.